### PR TITLE
[ISSUE-2] Switch logo to title image instead of title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,9 +24,8 @@ plugins:
 
 
 logo: /images/logo.png
-avatar: /images/logo.png
 round-avatar: false
-#title-img: /images/logo.png
+title-img: /images/logo.png
 
 navbar-links:
   Overview: "overview"


### PR DESCRIPTION
The logo is currently off center.  Under the defaults for this theme, you can use either a site title or site titleimage:

https://github.com/daattali/beautiful-jekyll/blob/610af684efcfda25fad058da6818a37cfa882dc3/_includes/nav.html#L3-L7

I switched it to using the logo as a title instead of an avatar.  This doesn't look as broken but loses the domain name as a title.

![logo_instead_of_title_1](https://user-images.githubusercontent.com/62413667/103843104-11205400-504c-11eb-89f1-921746bcecb4.png)
![logo_instead_of_title_2](https://user-images.githubusercontent.com/62413667/103843107-12518100-504c-11eb-803d-51e8469373e8.png)
![logo_offcenter](https://user-images.githubusercontent.com/62413667/103843109-12518100-504c-11eb-922d-eb30c971a323.png)
